### PR TITLE
Add simulated support for audio port configuration and audio patches

### DIFF
--- a/device.c
+++ b/device.c
@@ -534,10 +534,58 @@ int adev_get_audio_port(struct audio_hw_device *dev, struct audio_port *port)
 
 int adev_set_audio_port_config(struct audio_hw_device *dev, const struct audio_port_config *config)
 {
-    LOG_FN_NAME_WITH_ARGS("(%p, id:%d, role:%d, type:%d, config_mask:0x%x, "
-            "rate:%d, channel_mask:0x%x, format:%d)",
-            dev, config->id, config->role, config->type, config->config_mask,
-            config->sample_rate, config->channel_mask, config->format);
-    /* TODO To implement */
-    return -ENOSYS;
+    x_audio_device_t *xdev = (x_audio_device_t*)dev;
+
+    if ((dev == NULL) || (config == NULL)) {
+        return -EINVAL;
+    }
+
+    LOG_FN_NAME_WITH_ARGS("(%p, id:%d, role:%d, type:%d, config_mask:0x%x)",
+            dev, config->id, config->role, config->type, config->config_mask);
+
+    /* check that we are called for correct port type */
+    switch (config->type) {
+    case AUDIO_PORT_TYPE_DEVICE:
+        /* set config for audio_port_config_device_ext */
+        break;
+    case AUDIO_PORT_TYPE_MIX:
+        /* can't set config for audio_port_config_mix_ext */
+        LOG_FN_PARAMETERS("Not supported port type.");
+        return -ENOSYS;
+    case AUDIO_PORT_TYPE_SESSION:
+        /* can't set config for audio_port_config_session_ext */
+        LOG_FN_PARAMETERS("Not supported port type.");
+        return -ENOSYS;
+    default:
+        /* can't set config for not clear port type */
+        LOG_FN_PARAMETERS("Not supported port type.");
+        return -ENOSYS;
+    }
+
+    pthread_mutex_lock(&xdev->lock);
+    /* what should be configured? */
+    if ((config->config_mask & AUDIO_PORT_CONFIG_SAMPLE_RATE) != 0) {
+        LOG_FN_PARAMETERS("rate:%d", config->sample_rate);
+        /* has supported value? */
+        /* set new value */
+    }
+    if ((config->config_mask & AUDIO_PORT_CONFIG_CHANNEL_MASK) != 0) {
+        LOG_FN_PARAMETERS("channel_mask:0x%x", config->channel_mask);
+        /* has supported value? */
+        /* set new value */
+    }
+    if ((config->config_mask & AUDIO_PORT_CONFIG_FORMAT) != 0) {
+        LOG_FN_PARAMETERS("format:%d", config->format);
+        /* has supported value? */
+        /* set new value */
+    }
+    if ((config->config_mask & AUDIO_PORT_CONFIG_GAIN) != 0) {
+        LOG_FN_PARAMETERS("gain.index:%d, .mode:%d, .channel_mask:0x%x, values[], .ramp:%d",
+        config->gain.index, config->gain.mode, config->gain.channel_mask,
+        config->gain.ramp_duration_ms);
+        /* not possible to set gain in current configuration */
+    }
+    pthread_mutex_unlock(&xdev->lock);
+
+    return 0;
 }

--- a/device.c
+++ b/device.c
@@ -514,15 +514,18 @@ int adev_create_audio_patch(struct audio_hw_device *dev,
                 sinks[i].sample_rate, sinks[i].channel_mask, sinks[i].format);
     }
 
-    /* can't be implemented for current configuration */
-    return -ENOSYS;
+    /* for now we can only simulate that we created patch,
+       so let's return id of first sink */
+    *handle = sinks[0].id;
+    return 0;
 }
 
 int adev_release_audio_patch(struct audio_hw_device *dev, audio_patch_handle_t handle)
 {
     LOG_FN_NAME_WITH_ARGS("(%p, patch:%d)", dev, handle);
-    /* can't be implemented for current configuration */
-    return -ENOSYS;
+    /* can't be implemented for current configuration,
+     * so we will simulate success */
+    return 0;
 }
 
 int adev_get_audio_port(struct audio_hw_device *dev, struct audio_port *port)


### PR DESCRIPTION
This function is required for correct work of buses.
But we can't change configs for now, so we just check
input params and provide some debug traces.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>