### PR TITLE
Fix exit from standby for streams

### DIFF
--- a/stream_in.c
+++ b/stream_in.c
@@ -204,17 +204,17 @@ ssize_t in_read(struct audio_stream_in *stream, void* buffer, size_t bytes)
     pthread_mutex_lock(&xin->lock);
 
     if (xin->standby) {
-        xin->standby = false;
         /* turn device on */
         xin->p_handle = pcm_open(xin->p_card_id, xin->p_dev_id, PCM_IN, &(xin->p_config));
         if ((xin->p_handle == NULL) || (!pcm_is_ready(xin->p_handle))) {
-            ALOGE("%s failed. Can't reopen stream on device.", __FUNCTION__);
+            ALOGE("%s() failed (%d). Can't reopen stream on device.", __FUNCTION__, errno);
             if (xin->p_handle != NULL) {
                 pcm_close(xin->p_handle);
             }
             pthread_mutex_unlock(&xin->lock);
-            return -ENOMEM;
+            return -errno;
         }
+        xin->standby = false;
     }
     pcm_res = pcm_read(xin->p_handle, buffer, bytes);
 

--- a/stream_out.c
+++ b/stream_out.c
@@ -223,18 +223,18 @@ ssize_t out_write(struct audio_stream_out *stream, const void* buffer, size_t by
     pthread_mutex_lock(&xout->lock);
 
     if (xout->standby) {
-        xout->standby = false;
         /* turn device on */
         xout->p_handle = pcm_open(xout->p_card_id, xout->p_dev_id, PCM_OUT, &(xout->p_config));
         if ((xout->p_handle == NULL) || (!pcm_is_ready(xout->p_handle))) {
-            ALOGE("%s() failed. Can't reopen stream on device.", __FUNCTION__);
+            ALOGE("%s() failed (%d). Can't reopen stream on device.", __FUNCTION__, errno);
             if (xout->p_handle != NULL) {
                 pcm_close(xout->p_handle);
                 xout->p_handle = NULL;
             }
             pthread_mutex_unlock(&xout->lock);
-            return -ENOMEM;
+            return -errno;
         }
+        xout->standby = false;
     }
 
     frames = bytes / xout->frame_size;


### PR DESCRIPTION
Reset standby flag only after successful reopen of stream.
Exact error code from pcm is reported to caller and logged.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>