### PR TITLE
Handle unrecoverable errors during write to pcm device

### DIFF
--- a/stream_out.h
+++ b/stream_out.h
@@ -49,6 +49,7 @@ typedef struct x_stream_out {
     size_t frame_size;
     uint32_t buffer_latency;
     bool muted;
+    int error_cntr;
 } x_stream_out_t;
 
 /**


### PR DESCRIPTION
In case of permanent error, like disappearing of pcm device,
we need to put stream into standby.
This allows to reopen device when it appears again.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>