### PR TITLE
Fix Audio HAL for VNDK build

### DIFF
--- a/stream_in.c
+++ b/stream_in.c
@@ -28,6 +28,7 @@
 /* standard headers */
 #include <stdlib.h>
 #include <inttypes.h>
+#include <pthread.h>
 /* android headers */
 #include <log/log.h>
 /* local headers*/

--- a/stream_out.c
+++ b/stream_out.c
@@ -28,6 +28,8 @@
 /* standard headers */
 #include <stdlib.h>
 #include <inttypes.h>
+#include <pthread.h>
+#include <unistd.h>
 /* android headers */
 #include <log/log.h>
 #include <cutils/str_parms.h>


### PR DESCRIPTION
During VNDK build several default global header search paths are removed.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>