### PR TITLE
Fix issues discovered by VTS

### DIFF
--- a/audio_hw_config.c
+++ b/audio_hw_config.c
@@ -74,6 +74,37 @@ const unsigned int xa_supported_rates_in[] = {8000, 11025, 12000, 16000, 22050, 
 /* android-side formats */
 const unsigned int xa_supported_aformats[] = {AUDIO_FORMAT_PCM_16_BIT};
 
+void get_supported_in_rates_as_string(char * pbuf, size_t buf_size)
+{
+    int i;
+    char temp[10];
+    for (i = 0; i < sizeof(xa_supported_rates_in)/sizeof(xa_supported_rates_in[0]); i++) {
+        sprintf(temp, "%d|", xa_supported_rates_in[i]);
+        if ((strlen(pbuf) + strlen(temp) + 1) < buf_size) {
+            strcat(pbuf, temp);
+        }
+    }
+    if (strlen(pbuf) > 0) {
+        /* remove last '|' */
+        pbuf[strlen(pbuf)-1] = 0;
+    }
+}
+
+void get_supported_out_rates_as_string(char * pbuf, size_t buf_size)
+{
+    int i;
+    char temp[10];
+    for (i = 0; i < sizeof(xa_supported_rates_out)/sizeof(xa_supported_rates_out[0]); i++) {
+        sprintf(temp, "%d|", xa_supported_rates_out[i]);
+        if ((strlen(pbuf) + strlen(temp) + 1) < buf_size) {
+            strcat(pbuf, temp);
+        }
+    }
+    if (strlen(pbuf) > 0) {
+        /* remove last '|' */
+        pbuf[strlen(pbuf)-1] = 0;
+    }
+}
 
 /* check that parameters are supported for input stream */
 bool is_config_supported_in(const audio_config_t * config)

--- a/audio_hw_config.c
+++ b/audio_hw_config.c
@@ -69,8 +69,8 @@ xa_device_map_t xa_output_map[NUMBER_OF_DEVICES_OUT] =
 const unsigned int xa_supported_channels_out[] = {1, 2};
 const unsigned int xa_supported_channels_in[] = {1, 2};
 /* sample rates */
-const unsigned int xa_supported_rates_out[] = {8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000};
-const unsigned int xa_supported_rates_in[] = {8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000};
+const unsigned int xa_supported_rates_out[] = {8000, 11025, 12000, 16000, 22050, 32000, 44100, 48000};
+const unsigned int xa_supported_rates_in[] = {8000, 11025, 12000, 16000, 22050, 32000, 44100, 48000};
 /* android-side formats */
 const unsigned int xa_supported_aformats[] = {AUDIO_FORMAT_PCM_16_BIT};
 

--- a/audio_hw_config.h
+++ b/audio_hw_config.h
@@ -68,6 +68,12 @@ extern xa_device_map_t xa_input_map[NUMBER_OF_DEVICES_IN];
 /* map for output devices */
 extern xa_device_map_t xa_output_map[NUMBER_OF_DEVICES_OUT];
 
+/* print string presentation of supported sample rates for input stream */
+void get_supported_in_rates_as_string(char * pbuf, size_t buf_size);
+
+/* print string presentation of supported sample rates for output stream */
+void get_supported_out_rates_as_string(char * pbuf, size_t buf_size);
+
 /* return true if config is supported for input stream */
 bool is_config_supported_in(const audio_config_t * config);
 

--- a/device.c
+++ b/device.c
@@ -513,9 +513,50 @@ int adev_get_microphones(const struct audio_hw_device *dev,
                        struct audio_microphone_characteristic_t *mic_array,
                        size_t *mic_count)
 {
+    x_audio_device_t *xdev = (x_audio_device_t*)dev;
+    unsigned int i;
+
+    if ((xdev == NULL) || (mic_array == NULL) || (mic_count == NULL)) {
+        return -EINVAL;
+    }
+
+    pthread_mutex_lock(&xdev->lock);
     LOG_FN_NAME_WITH_ARGS("(%p)", dev);
-    /* TODO To implement */
-    return -ENOSYS;
+
+    *mic_count = NUMBER_OF_DEVICES_IN;
+    for (i = 0; i < NUMBER_OF_DEVICES_IN; i++) {
+        memset(&(mic_array[i]), 0, sizeof(mic_array[0]));
+        /*
+        TODO: do we need to store device_id in xa_input_map ?
+        mic_array[i].device_id[AUDIO_MICROPHONE_ID_MAX_LEN] = 0;
+        mic_array[i].id = 0;
+        */
+        mic_array[i].device = xa_input_map[i].device_type_mask;
+        strncpy(mic_array[i].address,
+                AUDIO_BOTTOM_MICROPHONE_ADDRESS,
+                AUDIO_DEVICE_MAX_ADDRESS_LEN - 1);
+        memset(mic_array[i].channel_mapping,
+               AUDIO_MICROPHONE_CHANNEL_MAPPING_UNUSED,
+               AUDIO_CHANNEL_COUNT_MAX);
+        mic_array[i].location = AUDIO_MICROPHONE_LOCATION_MAINBODY;
+        mic_array[i].group              = 0;
+        mic_array[i].index_in_the_group = 0;
+        mic_array[i].sensitivity    = AUDIO_MICROPHONE_SENSITIVITY_UNKNOWN;
+        mic_array[i].max_spl        = AUDIO_MICROPHONE_SPL_UNKNOWN;
+        mic_array[i].min_spl        = AUDIO_MICROPHONE_SPL_UNKNOWN;
+        mic_array[i].directionality = AUDIO_MICROPHONE_DIRECTIONALITY_UNKNOWN;
+        mic_array[i].num_frequency_responses = 0;
+        /* num_frequency_responses is 0 so no need to set frequency_responses[] */
+        mic_array[i].geometric_location.x = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+        mic_array[i].geometric_location.y = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+        mic_array[i].geometric_location.z = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+        mic_array[i].orientation.x        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+        mic_array[i].orientation.y        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+        mic_array[i].orientation.z        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    }
+
+    pthread_mutex_unlock(&xdev->lock);
+    return 0;
 }
 
 int adev_dump(const struct audio_hw_device *dev, int fd)

--- a/stream_in.c
+++ b/stream_in.c
@@ -400,9 +400,48 @@ int in_get_active_microphones(const struct audio_stream_in *stream,
                               struct audio_microphone_characteristic_t *mic_array,
                               size_t *mic_count)
 {
+    x_stream_in_t *xin = (x_stream_in_t*)stream;
+
+    if ((xin == NULL) || (mic_array == NULL) || (mic_count == NULL)) {
+        return -EINVAL;
+    }
+
+    pthread_mutex_lock(&xin->lock);
     LOG_FN_NAME_WITH_ARGS("(%p)", stream);
-    /* TODO To implement */
-    return -ENOSYS;
+
+    /* this functon is called only on active stream,
+       so  we always have just one mic active */
+    *mic_count = 1;
+    memset(&(mic_array[0]), 0, sizeof(mic_array[0]));
+    /*
+    mic_array[0].device_id[AUDIO_MICROPHONE_ID_MAX_LEN] = 0;
+    mic_array[0].id = 0;
+    */
+    mic_array[0].device = xin->a_dev;
+    strncpy(mic_array[0].address,
+            AUDIO_BOTTOM_MICROPHONE_ADDRESS,
+            AUDIO_DEVICE_MAX_ADDRESS_LEN - 1);
+    memset(mic_array[0].channel_mapping,
+           AUDIO_MICROPHONE_CHANNEL_MAPPING_UNUSED,
+           AUDIO_CHANNEL_COUNT_MAX);
+    mic_array[0].location = AUDIO_MICROPHONE_LOCATION_MAINBODY;
+    mic_array[0].group              = 0;
+    mic_array[0].index_in_the_group = 0;
+    mic_array[0].sensitivity    = AUDIO_MICROPHONE_SENSITIVITY_UNKNOWN;
+    mic_array[0].max_spl        = AUDIO_MICROPHONE_SPL_UNKNOWN;
+    mic_array[0].min_spl        = AUDIO_MICROPHONE_SPL_UNKNOWN;
+    mic_array[0].directionality = AUDIO_MICROPHONE_DIRECTIONALITY_UNKNOWN;
+    mic_array[0].num_frequency_responses = 0;
+    /* num_frequency_responses is 0 so no need to set frequency_responses[] */
+    mic_array[0].geometric_location.x = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    mic_array[0].geometric_location.y = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    mic_array[0].geometric_location.z = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    mic_array[0].orientation.x        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    mic_array[0].orientation.y        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+    mic_array[0].orientation.z        = AUDIO_MICROPHONE_COORDINATE_UNKNOWN;
+
+    pthread_mutex_unlock(&xin->lock);
+    return 0;
 }
 
 void in_update_sink_metadata(struct audio_stream_in *stream,

--- a/stream_in.c
+++ b/stream_in.c
@@ -342,7 +342,7 @@ int in_create_mmap_buffer(const struct audio_stream_in *stream,
 {
     LOG_FN_NAME_WITH_ARGS("(%p)", stream);
     /* MMAP is not supported for now */
-    return -ENODEV;
+    return -ENOSYS;
 }
 
 int in_get_mmap_position(const struct audio_stream_in *stream,
@@ -350,7 +350,7 @@ int in_get_mmap_position(const struct audio_stream_in *stream,
 {
     LOG_FN_NAME_WITH_ARGS("(%p)", stream);
     /* MMAP is not supported for now */
-    return -ENODATA;
+    return -ENOSYS;
 }
 
 int in_get_active_microphones(const struct audio_stream_in *stream,

--- a/stream_out.c
+++ b/stream_out.c
@@ -167,6 +167,12 @@ int out_set_parameters(struct audio_stream *stream, const char *kv_pairs)
 
     pthread_mutex_lock(&xout->lock);
 
+    if (kv_pairs[0] == '\0') {
+        /* it's OK to receive empty string */
+        pthread_mutex_unlock(&xout->lock);
+        return 0;
+    }
+
     if (!xout->standby) {
         /* we do not change parameters during playback,
          * so we return ENOSYS according to API */

--- a/stream_out.c
+++ b/stream_out.c
@@ -426,34 +426,6 @@ int out_set_callback(struct audio_stream_out *stream, stream_callback_t callback
     return -ENOSYS;
 }
 
-int out_pause(struct audio_stream_out* stream)
-{
-    LOG_FN_NAME_WITH_ARGS("(%p)", stream);
-    /* Applicable only for offloaded (DSP) playback. Not supported on current configuration. */
-    return -ENOSYS;
-}
-
-int out_resume(struct audio_stream_out* stream)
-{
-    LOG_FN_NAME_WITH_ARGS("(%p)", stream);
-    /* Applicable only for offloaded (DSP) playback. Not supported on current configuration. */
-    return -ENOSYS;
-}
-
-int out_drain(struct audio_stream_out* stream, audio_drain_type_t type )
-{
-    LOG_FN_NAME_WITH_ARGS("(%p, type:%d)", stream, type);
-    /* Applicable only for offloaded (DSP) playback. Not supported on current configuration. */
-    return -ENOSYS;
-}
-
-int out_flush(struct audio_stream_out* stream)
-{
-    LOG_FN_NAME_WITH_ARGS("(%p)", stream);
-    /* Applicable only for offloaded (DSP) playback. Not supported on current configuration. */
-    return -ENOSYS;
-}
-
 int out_get_presentation_position(const struct audio_stream_out *stream,
                            uint64_t *frames, struct timespec *timestamp)
 {
@@ -600,10 +572,17 @@ int out_create(struct audio_hw_device *dev,
     xout->astream.get_render_position = out_get_render_position;
     xout->astream.get_next_write_timestamp = out_get_next_write_timestamp;
     xout->astream.set_callback = out_set_callback;
-    xout->astream.pause = out_pause;
-    xout->astream.resume = out_resume;
-    xout->astream.drain = out_drain;
-    xout->astream.flush = out_flush;
+    /* If we do not support pause/resume and drain functionality then
+       we need to have NULL in corresponding fields
+       instead of return ENOSYS in function.
+
+       There are functions supportsPauseAndResume() and supportsDrain()
+       in upper level that check corresponding fields for NULL
+       to determine are functions supported. */
+    xout->astream.pause = NULL; /* must be NULL if not supported */
+    xout->astream.resume = NULL; /* must be NULL if not supported */
+    xout->astream.drain = NULL; /* must be NULL if not supported */
+    xout->astream.flush = NULL; /* set to NULL as optional function depending on pause */
     xout->astream.get_presentation_position = out_get_presentation_position;
     xout->astream.start = out_start;
     xout->astream.stop = out_stop;


### PR DESCRIPTION
Implement get_parameters() for input stream
Provide support for
* AUDIO_PARAMETER_STREAM_SUP_FORMATS
* AUDIO_PARAMETER_STREAM_SUP_SAMPLING_RATES (hardcoded)

---
Change return code for not supported mmap functions
Return ENOSYS as code expected by VTS.

---
Implement get_parameters() for output stream

---
Allow empty string for out_set_parameters()
According to VTS it's OK to send empty string as parameter to set.
So we will accept "no pairs found" in received string.

---
Remove stub functions related to offload playback

Following functions must be not defined if we do not support
corresponding functionality:
* pause
* resume
* drain

Upper level functions supportsPauseAndResume() and supportsDrain()
report functionality as supported if corresponding field is not NULL.
That's why we need to remove stubs for mentioned functions.
Also flush() function is removed because it depends on pause()
and also is optional.

---
Initial implementation for in_set_parameters()

For now function just check parameters and return ENOSYS
but this is base for future functionality.

---
Implement basic functionality for get microphones

Implemented:
* adev_get_microphones()
* in_get_active_microphones()

Most fields are set to 0 or unknown state, but we need this
to pass VTS test.